### PR TITLE
chore: update build to v14

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,4 +1,4 @@
-// build.js — Vercel SPA build (v13)
+// build.js — Vercel SPA build (v14)
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -54,7 +54,7 @@ try {
   ensureDir(distDir);
 
   const token   = process.env.NEXT_PUBLIC_MAPBOX_TOKEN || "";
-  const buildId = "v13";
+  const buildId = "v14";
 
   const cfg = `// generated at build time
 export const MAPBOX_TOKEN = ${JSON.stringify(token)};
@@ -76,7 +76,7 @@ copyDir(path.join(ROOT, "public"), OUT);
 copy(path.join(ROOT, "map.js"),    path.join(OUT, "map.js"));
 copy(path.join(ROOT, "styles.css"),path.join(OUT, "styles.css"));
 copy(path.join(ROOT, "index.html"),path.join(OUT, "index.html"));
-copy(path.join(ROOT, 'sw-v13.js'), path.join(OUT, 'sw-v13.js'));
+copy(path.join(ROOT, 'sw-v14.js'), path.join(OUT, 'sw-v14.js'));
 copy(path.join(ROOT, "manifest.json"), path.join(OUT, "manifest.json"));
 
 console.log("✅ Build Completed in /vercel/output");

--- a/index.html
+++ b/index.html
@@ -15,15 +15,15 @@
   <meta name="apple-mobile-web-app-title" content="It's Gountain" />
 
   <!-- Icons (con cache-busting) -->
-  <link rel="icon" type="image/png" sizes="192x192" href="/assets/GountainTime-192.png?v=13" />
-  <link rel="apple-touch-icon" sizes="512x512" href="/assets/GountainTime-512.png?v=13" />
+  <link rel="icon" type="image/png" sizes="192x192" href="/assets/GountainTime-192.png?v=14" />
+  <link rel="apple-touch-icon" sizes="512x512" href="/assets/GountainTime-512.png?v=14" />
 
   <!-- Mapbox GL v2 -->
   <link href="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.css" rel="stylesheet" />
   <script src="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.js" defer></script>
 
   <!-- CSS de la app -->
-  <link rel="stylesheet" href="/styles.css?v=13" />
+  <link rel="stylesheet" href="/styles.css?v=14" />
 </head>
 <body>
   <!-- Topbar -->
@@ -125,14 +125,14 @@
   <div id="map-error" class="hidden" role="alert"></div>
 
   <!-- JS de tu app -->
-  <script type="module" src="/dist/app.bundle.js?v=13"></script>
-  <script type="module" src="/map.js?v=13"></script>
+  <script type="module" src="/dist/app.bundle.js?v=14"></script>
+  <script type="module" src="/map.js?v=14"></script>
 
   <!-- SW -->
   <script>
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', () => {
-        navigator.serviceWorker.register('/sw-v13.js?v=13').catch(console.error);
+        navigator.serviceWorker.register('/sw-v14.js?v=14').catch(console.error);
       });
     }
   </script>

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Gountain Time",
   "short_name": "Gountain",
-  "start_url": "/?v=13",
+  "start_url": "/?v=14",
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#00a0c6",

--- a/map.js
+++ b/map.js
@@ -1,4 +1,4 @@
-// map.js — v13 (popup inteligente + safe areas móvil)
+// map.js — v14 (popup inteligente + safe areas móvil)
 import { MAPBOX_TOKEN, getBuildId } from '/dist/config.js';
 
 /* global mapboxgl */

--- a/sw-v14.js
+++ b/sw-v14.js
@@ -1,5 +1,5 @@
-// sw-v13.js
-const CACHE_NAME = "gountain-cache-v13";
+// sw-v14.js
+const CACHE_NAME = "gountain-cache-v14";
 const OFFLINE_URLS = [
   "/", "/index.html", "/styles.css",
   "/map.js",


### PR DESCRIPTION
## Summary
- rename service worker to `sw-v14.js` and bump cache name
- bump app assets and service worker references to v14
- update build script and manifest to use v14

## Testing
- `npm run build`
- `rg 'v13' -n`


------
https://chatgpt.com/codex/tasks/task_e_68acd51378a88321a7bf72f4f9210f4f