### PR TITLE
feat: add layers toggle for basemap switcher

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,17 @@
     <!-- Mapa -->
     <section id="map-container">
       <div id="map"></div>
-      <div id="basemap-switcher" class="basemap-switcher" aria-label="Map style"></div>
+      <!-- Botón Layers -->
+      <button id="layers-toggle" class="layers-btn" aria-label="Mostrar estilos de mapa" aria-pressed="false">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" aria-hidden="true" class="icon">
+          <polygon points="12 3 20 8 12 13 4 8"></polygon>
+          <path d="M20 12L12 17 4 12"></path>
+        </svg>
+        <span class="label">Layers</span>
+      </button>
+
+      <!-- Switcher oculto por defecto -->
+      <div id="basemap-switcher" class="basemap-switcher hidden" aria-label="Map style"></div>
       <div id="dest-chips" class="destination-chips" aria-label="Destinations"></div>
       <div id="map-error" class="hidden" role="alert"></div>
     </section>

--- a/map.js
+++ b/map.js
@@ -94,20 +94,35 @@ function buildStyleSwitcher() {
   const host = document.getElementById('basemap-switcher');
   if (!host) return;
 
+  // Toggle botón Layers
+  const toggleBtn = document.getElementById('layers-toggle');
+  const setPressed = (v) => toggleBtn?.setAttribute('aria-pressed', String(v));
+  toggleBtn?.addEventListener('click', (e) => {
+    e.stopPropagation();
+    host.classList.toggle('hidden');
+    setPressed(!host.classList.contains('hidden'));
+  });
+
+  // Auto-ocultar al interactuar con el mapa
+  const hideSwitcher = () => { host.classList.add('hidden'); setPressed(false); };
+  map.on('click', hideSwitcher);
+  map.on('dragstart', hideSwitcher);
+  map.on('zoomstart', hideSwitcher);
+  host.addEventListener('click', (e) => e.stopPropagation()); // no cerrar por clicks internos
+
+  // Botones del switcher
   const buttons = [
     ['Standard','standard'],
     ['Satellite','satellite'],
     ['Hybrid','hybrid'],
-    ['3D','standard'] // 3D = pitch/bearing toggle
+    ['3D','standard']
   ];
-
   host.innerHTML = '';
   buttons.forEach(([label, key]) => {
     const btn = document.createElement('button');
-    btn.textContent = label;
-
+   btn.textContent = label;
     btn.addEventListener('click', () => {
-      if (label === '3D') { toggle3D(); setActive(btn); return; }
+      if (label === '3D') { toggle3D(); setActive(btn); hideSwitcher(); return; }
       const newStyle = STYLES[key];
       map.setStyle(newStyle);
       map.once('style.load', () => {
@@ -115,12 +130,12 @@ function buildStyleSwitcher() {
         reattachSourcesAndLayers();
       });
       setActive(btn);
+      hideSwitcher();
     });
-
     host.appendChild(btn);
   });
 
-  function setActive(activeBtn) {
+  function setActive(activeBtn){
     [...host.children].forEach(b => b.classList.toggle('active', b === activeBtn));
   }
   if (host.firstChild) host.firstChild.classList.add('active');

--- a/styles.css
+++ b/styles.css
@@ -254,3 +254,16 @@ button:focus-visible, a:focus-visible, select:focus-visible{
 #layout #sidebar{ background:rgba(255,0,0,.18)!important; }
 #map-container{ background:rgba(0,128,255,.18)!important; }
 */
+
+.basemap-switcher.hidden{display:none!important;}
+.layers-btn{
+  position:absolute; top:calc(var(--navbar-height) + 0.75rem); right:0.75rem;
+  display:inline-flex; align-items:center; gap:.5rem;
+  padding:.5rem .65rem; border-radius:.625rem;
+  background:#111827d0; border:1px solid var(--border);
+  backdrop-filter:blur(8px); -webkit-backdrop-filter:blur(8px);
+  color:#fff; cursor:pointer; z-index:1002; font-size:.9rem;
+}
+.layers-btn:hover{box-shadow:0 0 0 1px #ffffff22 inset;}
+.layers-btn .icon{width:20px;height:20px;color:#fff;display:block;}
+@media (max-width:480px){ .layers-btn .label{display:none;} }


### PR DESCRIPTION
## Summary
- add Layers button to show/hide basemap switcher and default it hidden
- style new Layers button and hidden switcher
- rebuild style switcher to toggle via button, auto-hide on map interactions, and track active style

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0cade667483218075b1f154b9c6f3